### PR TITLE
Add _write to support system-wide printf.

### DIFF
--- a/ch32v003_uart.h
+++ b/ch32v003_uart.h
@@ -201,6 +201,19 @@ uint16_t UART_getc(void)
 // --------------------------------------------------------
 #if defined (UART_MODE_TX)
 /**
+ * @brief write function required by printf
+ * 
+ * @param fd file descriptor
+ * @param buf pointer to the source buffer
+ * @param size how many bytes to send
+ * @return int number of bytes sent
+ */
+int _write(int fd, const char *buf, int size)
+{
+	return UART_write(buf, size);
+}
+// --------------------------------------------------------
+/**
  * @brief put one byte into the transmit buffer, start TX
  * 
  * @param data byte to send


### PR DESCRIPTION
This makes the default printf work (UART_printf is not needed anymore).

It also requires ading 2 lines in ch32v003fun.c to make _write "weak".

+// declare as weak so that it can be overridden.
+int _write(int fd, const char *buf, int size) __attribute__((weak));